### PR TITLE
Migrate slack notifications to composite action

### DIFF
--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -3,3 +3,6 @@ rules:
     config:
       policies:
         "*": ref-pin
+  secrets-outside-env:
+    ignore:
+      - docker-push-containers-to-dockerhub.yaml

--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -5,4 +5,5 @@ rules:
         "*": ref-pin
   secrets-outside-env:
     ignore:
+      - docker-build-container.yaml
       - docker-push-containers-to-dockerhub.yaml

--- a/.github/workflows/add-labels-standardized.yaml
+++ b/.github/workflows/add-labels-standardized.yaml
@@ -15,14 +15,6 @@ jobs:
     secrets:
       ORG_MEMBERSHIP_TOKEN: ${{ secrets.ORG_MEMBERSHIP_TOKEN }}
       MEMBERS: ${{ secrets.SENZING_MEMBERS }}
-    uses: senzing-factory/build-resources/.github/workflows/add-labels-to-issue.yaml@v4
-
-  slack-notification:
-    needs: [add-issue-labels]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-issue-labels.result) }}
-    secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
-    with:
-      job-status: ${{ needs.add-issue-labels.result }}
+    uses: senzing-factory/build-resources/.github/workflows/add-labels-to-issue.yaml@v4

--- a/.github/workflows/add-to-project-senzing-dependabot.yaml
+++ b/.github/workflows/add-to-project-senzing-dependabot.yaml
@@ -12,16 +12,8 @@ jobs:
       repository-projects: write
     secrets:
       PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     uses: senzing-factory/build-resources/.github/workflows/add-to-project-dependabot.yaml@v4
     with:
       project: ${{ vars.SENZING_GITHUB_ORGANIZATION_PROJECT }}
-
-  slack-notification:
-    needs: [add-to-project-dependabot]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project-dependabot.result) }}
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
-    with:
-      job-status: ${{ needs.add-to-project-dependabot.result }}

--- a/.github/workflows/add-to-project-senzing.yaml
+++ b/.github/workflows/add-to-project-senzing.yaml
@@ -14,17 +14,9 @@ jobs:
       repository-projects: write
     secrets:
       PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     uses: senzing-factory/build-resources/.github/workflows/add-to-project.yaml@v4
     with:
       project-number: ${{ vars.SENZING_GITHUB_ORGANIZATION_PROJECT }}
       org: ${{ vars.SENZING_GITHUB_ACCOUNT_NAME }}
-
-  slack-notification:
-    needs: [add-to-project]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project.result) }}
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
-    with:
-      job-status: ${{ needs.add-to-project.result }}

--- a/.github/workflows/docker-build-container.yaml
+++ b/.github/workflows/docker-build-container.yaml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/docker-push-containers-to-dockerhub.yaml
+++ b/.github/workflows/docker-push-containers-to-dockerhub.yaml
@@ -9,8 +9,6 @@ permissions: {}
 
 jobs:
   docker-push-containers-to-dockerhub:
-    outputs:
-      status: ${{ job.status }}
     permissions:
       attestations: write
       contents: write
@@ -33,13 +31,10 @@ jobs:
           push: true
           sign-image: true
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-
-  slack-notification:
-    needs: [docker-push-containers-to-dockerhub]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.docker-push-containers-to-dockerhub.outputs.status) }}
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
-    with:
-      job-status: ${{ needs.docker-push-containers-to-dockerhub.outputs.status }}
+      - name: Notify Slack on failure
+        if: (failure() || cancelled())
+        uses: senzing-factory/build-resources/slack-failure-notification@v4
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -1,8 +1,6 @@
 name: lint workflows
 
 on:
-  push:
-    branches-ignore: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## Summary
- Replace standalone `slack-notification` jobs with inline composite action step from `senzing-factory/build-resources/slack-failure-notification@v4`
- Pass `SLACK_BOT_TOKEN` and `SLACK_CHANNEL` secrets to reusable workflows (`add-labels-to-issue`, `add-to-project`, `add-to-project-dependabot`) that now handle notifications internally
- Add concurrency groups where missing (skip tag-only and project management workflows)
- Remove unused `outputs: status` from jobs that only existed for the old notification pattern
- Use `sdk-versions` composite action instead of hardcoded version lists (code-snippets-v4 only)

## Test plan
- [ ] Verify add-labels and add-to-project workflows still function on issue creation
- [ ] Verify build/test workflows notify on failure
- [ ] Verify concurrency cancels in-progress runs on new pushes